### PR TITLE
Handle invalid json response

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -1159,7 +1159,10 @@ module DocusignRest
     end
 
     def request_with_logging(http, request, uri, body=nil)
-      JSON.parse(unparsed_request_with_logging(http, request, uri, body))
+      unparsed_response = unparsed_request_with_logging(http, request, uri, body)
+      JSON.parse(unparsed_response)
+    rescue JSON::ParserError => e
+      { 'error_message' => e, 'response' => unparsed_response }
     end
 
     def unparsed_request_with_logging(http, request, uri, body=nil)


### PR DESCRIPTION
Handle unpredictable bad response from docusign api server. In this case `JSON::ParserError: A JSON text must at least contain two octets!` it's because of empty string response.