### PR TITLE
Fix parameter name type in DocusignRest::Client#void_envelope

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -1098,7 +1098,7 @@ module DocusignRest
           "voidedReason" => options[:voided_reason] || "No reason provided."
       }.to_json
 
-      uri = build_uri("/accounts/#{acct_id}/envelopes/#{options[:folder_id]}")
+      uri = build_uri("/accounts/#{acct_id}/envelopes/#{options[:envelope_id]}")
 
       http = initialize_net_http_ssl(uri)
       request = Net::HTTP::Put.new(uri.request_uri, headers(content_type))


### PR DESCRIPTION
Ref:
https://github.com/jondkinney/docusign_rest/commit/d03ec3fbe037ea62f9243dff8fdf4aeca8d4cd84